### PR TITLE
Add automatic PATH update for Vaultlet installation

### DIFF
--- a/vaultlet/post_install.py
+++ b/vaultlet/post_install.py
@@ -1,0 +1,19 @@
+import os
+import sys
+import subprocess
+
+def add_to_path():
+    path_to_add = os.path.join(sys.prefix, 'Scripts')
+    if os.name == 'nt':
+        # Windows
+        subprocess.call(['setx', 'PATH', f'%PATH%;{path_to_add}'])
+    else:
+        # Unix-based systems
+        bashrc_path = os.path.expanduser('~/.bashrc')
+        with open(bashrc_path, 'a') as bashrc:
+            bashrc.write(f'\nexport PATH=$PATH:{path_to_add}\n')
+        subprocess.call(['source', bashrc_path])
+
+if __name__ == '__main__':
+    add_to_path()
+    

--- a/vaultlet/pyproject.toml
+++ b/vaultlet/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vaultlet"
-version = "1.0.0"
+version = "1.0.1"
 description = "Securely inject env vars using Windows Credential Manager"
 authors = [{ name = "Steven Li", email = "stevenli6186@gmail.com" }]
 license = "MIT"

--- a/vaultlet/pyproject.toml
+++ b/vaultlet/pyproject.toml
@@ -1,3 +1,7 @@
+[build-system]
+requires = ["setuptools", "wheel"]
+build-backend = "setuptools.build_meta"
+
 [project]
 name = "vaultlet"
 version = "1.0.0"
@@ -9,3 +13,6 @@ dependencies = ["keyring"]
 [project.scripts]
 vaultlet = "vaultlet.__main__:main"
 vl = "vaultlet.__main__:main"
+
+[tool.setuptools]
+cmdclass = { "install": "post_install:PostInstallCommand" }

--- a/vaultlet/setup.py
+++ b/vaultlet/setup.py
@@ -1,0 +1,15 @@
+from setuptools import setup
+from setuptools.command.install import install
+import subprocess
+
+class PostInstallCommand(install):
+    """Post-installation for installation mode."""
+    def run(self):
+        install.run(self)
+        subprocess.call([sys.executable, 'post_install.py'])
+
+setup(
+    cmdclass={
+        'install': PostInstallCommand,
+    },
+)


### PR DESCRIPTION
**Description:**
This PR introduces a post-installation script that automatically adds the Vaultlet installation directory to the system PATH. This enhancement ensures that the `vaultlet` and `vl` commands are accessible from any command line prompt without requiring manual PATH updates.

**Changes:**
- Added `post_install.py` script to handle PATH updates.
- Modified `pyproject.toml` to include the custom installation command.
- Updated `setup.py` to run the post-installation script.

**Testing:**
1. Run `pip install -e .` from the root directory.
2. Verify that the `vaultlet` and `vl` commands are accessible from any command line prompt.
3. Ensure that the PATH update is persistent across new terminal sessions.

**Notes:**
- This change is applicable to both Windows and Unix-based systems.
- Users no longer need to manually update their PATH after installation.